### PR TITLE
Fix master mute toggle for speech test

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -77,37 +77,4 @@
     <button id="btn_start_baron" class="ms-btn" title="Start a 20:00 baron countdown">Start Baron (20:00)</button>
     <button id="btn_clear_timers" class="ms-btn" title="Stop all objective reminders">Clear timers</button>
   </div>
-</div>
-
-<!-- Put this AFTER the controls markup, BEFORE renderer.js -->
-<script>
-  (function () {
-    // Show live rate value
-    var rate = document.getElementById('opt_rate');
-    var rateVal = document.getElementById('opt_rate_val');
-    if (rate && rateVal) {
-      rate.addEventListener('input', function () {
-        rateVal.textContent = (+rate.value).toFixed(2) + '×';
-      });
-    }
-
-    // Master toggle ties to mute/unmute buttons
-    var master = document.getElementById('opt_master');
-    var muteBtn = document.getElementById('btn_mute');
-    var unmuteBtn = document.getElementById('btn_unmute');
-    if (master && muteBtn && unmuteBtn) {
-      master.addEventListener('change', function () {
-        if (master.checked) unmuteBtn.click(); else muteBtn.click();
-      });
-    }
-
-    // Keyboard shortcut: T = Speak test
-    document.addEventListener('keydown', function (ev) {
-      if (!ev.key) return;
-      if (ev.key.toLowerCase() === 't') {
-        var testBtn = document.getElementById('btn_test_voice');
-        if (testBtn) testBtn.click();
-      }
-    });
-  })();
-</script>
+  </div>

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -147,16 +147,25 @@ function initPanel() {
   const k = document.getElementById('opt_kills') as HTMLInputElement | null; if (k) k.checked = S.speakKills;
   const o = document.getElementById('opt_objectives') as HTMLInputElement | null; if (o) o.checked = S.speakObjectives;
   const m = document.getElementById('opt_mia') as HTMLInputElement | null; if (m) m.checked = S.speakMIA;
+  const master = document.getElementById('opt_master') as HTMLInputElement | null; if (master) master.checked = !S.muted;
   const rateEl = document.getElementById('opt_rate') as HTMLInputElement | null; if (rateEl) rateEl.value = String(S.rate);
+  const rateVal = document.getElementById('opt_rate_val') as HTMLElement | null; if (rateVal) rateVal.textContent = S.rate.toFixed(2) + '×';
 
   // Bind controls
   k?.addEventListener('change', e => { S.speakKills = (e.target as HTMLInputElement).checked; save(S); });
   o?.addEventListener('change', e => { S.speakObjectives = (e.target as HTMLInputElement).checked; save(S); });
   m?.addEventListener('change', e => { S.speakMIA = (e.target as HTMLInputElement).checked; save(S); });
-  rateEl?.addEventListener('input', e => setRate(parseFloat((e.target as HTMLInputElement).value)));
+  rateEl?.addEventListener('input', e => {
+    const val = parseFloat((e.target as HTMLInputElement).value);
+    setRate(val);
+    if (rateVal) rateVal.textContent = val.toFixed(2) + '×';
+  });
 
-  const mute = document.getElementById('btn_mute');     mute?.addEventListener('click', () => { S.muted = true;  save(S); setStatus('Muted', 'warn'); });
-  const unmute = document.getElementById('btn_unmute'); unmute?.addEventListener('click', () => { S.muted = false; save(S); setStatus('Unmuted', 'ok'); });
+  const doMute = () => { S.muted = true; save(S); master && (master.checked = false); setStatus('Muted', 'warn'); };
+  const doUnmute = () => { S.muted = false; save(S); master && (master.checked = true); setStatus('Unmuted', 'ok'); };
+  const mute = document.getElementById('btn_mute');     mute?.addEventListener('click', doMute);
+  const unmute = document.getElementById('btn_unmute'); unmute?.addEventListener('click', doUnmute);
+  master?.addEventListener('change', e => { (e.target as HTMLInputElement).checked ? doUnmute() : doMute(); });
 
   // Speak test – robust binding + global fallback
   const test = document.getElementById('btn_test_voice') as HTMLButtonElement | null;


### PR DESCRIPTION
## Summary
- Sync master enable/disable checkbox with stored mute state
- Update rate display and mute logic in TypeScript and drop redundant inline script

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:renderer`


------
https://chatgpt.com/codex/tasks/task_e_68981cb45b6083269854eb2d1236690d