### PR TITLE
Wire renderer script and modularize speech queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ In order to add more/remove certain ow-electron "packages" from the project, sim
   ...
 }
 ```
+
+## Voice coach quick test
+
+Build the renderer with `npm run build:renderer`, then load `dist/renderer/index.html` in an Overwolf window. Click **Speak test** (or press **T**) to hear the sample line and verify audio output. The **Enable voice** checkbox mirrors the master mute state so you can toggle speech on or off.

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,19 +1,19 @@
 <!-- MapSense Controls -->
 <style>
-  .ms-card{font:14px/1.3 system-ui, -apple-system, Segoe UI, Roboto, Arial;
-    border:1px solid #e3e3e6; border-radius:12px; padding:12px; margin:10px 0;
-    background:#fafafb}
-  .ms-row{display:flex; gap:16px; align-items:center; flex-wrap:wrap}
+  body{margin:0;padding:20px;font:14px/1.3 system-ui,-apple-system,Segoe UI,Roboto,Arial;background:linear-gradient(135deg,#f5f7fa,#e4e7eb)}
+  .ms-card{border:1px solid #e3e3e6;border-radius:12px;padding:12px;margin:10px 0;background:#fafafb;box-shadow:0 2px 4px rgba(0,0,0,.08)}
+  .ms-row{display:flex;gap:16px;align-items:center;flex-wrap:wrap}
   .ms-row + .ms-row{margin-top:8px}
-  .ms-switch{display:flex; gap:12px; align-items:center}
-  .ms-sep{height:1px; background:#eaeaf0; margin:10px 0}
-  .ms-badge{font-size:12px; padding:2px 8px; border-radius:999px; background:#eef3ff; color:#2b4bff}
-  .ms-btn{padding:6px 10px; border:1px solid #d7d7dd; border-radius:8px; background:#fff; cursor:pointer}
+  .ms-switch{display:flex;gap:12px;align-items:center}
+  .ms-sep{height:1px;background:#eaeaf0;margin:10px 0}
+  .ms-badge{font-size:12px;padding:2px 8px;border-radius:999px;background:#eef3ff;color:#2b4bff}
+  .ms-btn{padding:6px 10px;border:1px solid #d7d7dd;border-radius:8px;background:linear-gradient(#fff,#f0f0f0);cursor:pointer;transition:background .2s}
+  .ms-btn:hover{background:#f6f6f6}
   .ms-btn:active{transform:translateY(1px)}
-  .ms-inline{display:inline-flex; align-items:center; gap:8px}
-  .ms-small{font-size:12px; color:#666}
+  .ms-inline{display:inline-flex;align-items:center;gap:8px}
+  .ms-small{font-size:12px;color:#666}
   .ms-right{margin-left:auto}
-  .ms-hint{color:#888; font-size:12px}
+  .ms-hint{color:#888;font-size:12px}
   .ms-slider{width:180px}
 </style>
 
@@ -77,37 +77,6 @@
     <button id="btn_start_baron" class="ms-btn" title="Start a 20:00 baron countdown">Start Baron (20:00)</button>
     <button id="btn_clear_timers" class="ms-btn" title="Stop all objective reminders">Clear timers</button>
   </div>
-</div>
+  </div>
 
-<!-- Put this AFTER the controls markup, BEFORE renderer.js -->
-<script>
-  (function () {
-    // Show live rate value
-    var rate = document.getElementById('opt_rate');
-    var rateVal = document.getElementById('opt_rate_val');
-    if (rate && rateVal) {
-      rate.addEventListener('input', function () {
-        rateVal.textContent = (+rate.value).toFixed(2) + '×';
-      });
-    }
-
-    // Master toggle ties to mute/unmute buttons
-    var master = document.getElementById('opt_master');
-    var muteBtn = document.getElementById('btn_mute');
-    var unmuteBtn = document.getElementById('btn_unmute');
-    if (master && muteBtn && unmuteBtn) {
-      master.addEventListener('change', function () {
-        if (master.checked) unmuteBtn.click(); else muteBtn.click();
-      });
-    }
-
-    // Keyboard shortcut: T = Speak test
-    document.addEventListener('keydown', function (ev) {
-      if (!ev.key) return;
-      if (ev.key.toLowerCase() === 't') {
-        var testBtn = document.getElementById('btn_test_voice');
-        if (testBtn) testBtn.click();
-      }
-    });
-  })();
-</script>
+  <script defer src="renderer.js"></script>

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -155,7 +155,14 @@ function initPanel() {
 
   // Speak test – robust binding + global fallback
   const test = document.getElementById('btn_test_voice') as HTMLButtonElement | null;
-  const speakTest = () => { console.log('[UI] Speak test'); warmVoices(); enqueue('MapSense ready'); };
+  const speakTest = () => {
+    console.log('[UI] Speak test');
+    if (!voicesWarmed) {
+      warmVoices();
+      voicesWarmed = true;
+    }
+    enqueue('MapSense ready');
+  };
   test?.addEventListener('click', speakTest);
   (window as any).mapsenseSpeakTest = speakTest; // fallback if you want onclick="mapsenseSpeakTest()"
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,3 +1,4 @@
+import { createSpeechQueue, warmVoices } from './speech';
 console.log('renderer script');
 
 // ================= STATUS BADGE =================
@@ -22,26 +23,11 @@ const load = (): Settings => ({ ...DEFAULTS, ...JSON.parse(localStorage.getItem(
 const save = (s: Settings) => localStorage.setItem('mapsense_settings', JSON.stringify(s));
 let S = load();
 
-let speaking = false;
-const q: string[] = [];
 function setRate(rate:number){ S.rate = rate; save(S); }
-function enqueue(text: string) {
-  console.log('[enqueue]', text, '| muted=', S.muted);
-  if (S.muted) return;
-  q.push(text);
-  pump();
-}
-function pump() {
-  if (speaking || q.length === 0) return;
-  speaking = true;
-  const text = q.shift()!;
-  const u = new SpeechSynthesisUtterance(text);
-  u.rate = S.rate;
-  u.onstart = () => console.log('[TTS] start:', text);
-  u.onerror = (e) => console.warn('[TTS] error:', e);
-  u.onend = () => { console.log('[TTS] end'); speaking = false; pump(); };
-  try { speechSynthesis.speak(u); } catch (e) { console.warn('[TTS] speak threw', e); speaking = false; }
-}
+// Speech queue lives in its own module to keep renderer.ts lean
+const { enqueue } = createSpeechQueue(() => S.rate, () => S.muted);
+// Warm voices on first user interaction – some platforms ignore the first call otherwise
+document.addEventListener('click', warmVoices, { once: true });
 
 // --- COOLDOWNS ---
 const cd = new Map<string, number>();
@@ -147,20 +133,29 @@ function initPanel() {
   const k = document.getElementById('opt_kills') as HTMLInputElement | null; if (k) k.checked = S.speakKills;
   const o = document.getElementById('opt_objectives') as HTMLInputElement | null; if (o) o.checked = S.speakObjectives;
   const m = document.getElementById('opt_mia') as HTMLInputElement | null; if (m) m.checked = S.speakMIA;
+  const master = document.getElementById('opt_master') as HTMLInputElement | null; if (master) master.checked = !S.muted;
   const rateEl = document.getElementById('opt_rate') as HTMLInputElement | null; if (rateEl) rateEl.value = String(S.rate);
+  const rateVal = document.getElementById('opt_rate_val') as HTMLElement | null; if (rateVal) rateVal.textContent = S.rate.toFixed(2) + '×';
 
   // Bind controls
   k?.addEventListener('change', e => { S.speakKills = (e.target as HTMLInputElement).checked; save(S); });
   o?.addEventListener('change', e => { S.speakObjectives = (e.target as HTMLInputElement).checked; save(S); });
   m?.addEventListener('change', e => { S.speakMIA = (e.target as HTMLInputElement).checked; save(S); });
-  rateEl?.addEventListener('input', e => setRate(parseFloat((e.target as HTMLInputElement).value)));
+  rateEl?.addEventListener('input', e => {
+    const val = parseFloat((e.target as HTMLInputElement).value);
+    setRate(val);
+    if (rateVal) rateVal.textContent = val.toFixed(2) + '×';
+  });
 
-  const mute = document.getElementById('btn_mute');     mute?.addEventListener('click', () => { S.muted = true;  save(S); setStatus('Muted', 'warn'); });
-  const unmute = document.getElementById('btn_unmute'); unmute?.addEventListener('click', () => { S.muted = false; save(S); setStatus('Unmuted', 'ok'); });
+  const doMute = () => { S.muted = true; save(S); master && (master.checked = false); setStatus('Muted', 'warn'); };
+  const doUnmute = () => { S.muted = false; save(S); master && (master.checked = true); setStatus('Unmuted', 'ok'); };
+  const mute = document.getElementById('btn_mute');     mute?.addEventListener('click', doMute);
+  const unmute = document.getElementById('btn_unmute'); unmute?.addEventListener('click', doUnmute);
+  master?.addEventListener('change', e => { (e.target as HTMLInputElement).checked ? doUnmute() : doMute(); });
 
   // Speak test – robust binding + global fallback
   const test = document.getElementById('btn_test_voice') as HTMLButtonElement | null;
-  const speakTest = () => { console.log('[UI] Speak test'); enqueue('MapSense ready'); };
+  const speakTest = () => { console.log('[UI] Speak test'); warmVoices(); enqueue('MapSense ready'); };
   test?.addEventListener('click', speakTest);
   (window as any).mapsenseSpeakTest = speakTest; // fallback if you want onclick="mapsenseSpeakTest()"
 

--- a/src/renderer/speech.ts
+++ b/src/renderer/speech.ts
@@ -25,7 +25,7 @@ export function createSpeechQueue(getRate: RateGetter, isMuted: MutedGetter) {
     u.onerror = (e) => { console.warn('[TTS] error:', e); speaking = false; pump(); };
     u.onend = () => { console.log('[TTS] end'); speaking = false; pump(); };
     try { window.speechSynthesis.speak(u); }
-    catch (e) { console.warn('[TTS] speak threw', e); speaking = false; }
+    catch (e) { console.warn('[TTS] speak threw', e); speaking = false; pump(); }
   }
 
   function enqueue(text: string): void {

--- a/src/renderer/speech.ts
+++ b/src/renderer/speech.ts
@@ -1,0 +1,39 @@
+// Simple speech synthesis queue
+// Provides a lightweight API to enqueue lines of text
+// and handles rate/voice settings internally.
+
+export type RateGetter = () => number;
+export type MutedGetter = () => boolean;
+
+// Preload available voices to avoid the first call being ignored on some platforms
+export function warmVoices(): void {
+  // Fetch the voices list which triggers voice loading in Chrome based browsers
+  try { window.speechSynthesis.getVoices(); } catch {}
+}
+
+export function createSpeechQueue(getRate: RateGetter, isMuted: MutedGetter) {
+  let speaking = false;
+  const q: string[] = [];
+
+  function pump() {
+    if (speaking || q.length === 0) return;
+    speaking = true;
+    const text = q.shift()!;
+    const u = new SpeechSynthesisUtterance(text);
+    u.rate = getRate();
+    u.onstart = () => console.log('[TTS] start:', text);
+    u.onerror = (e) => { console.warn('[TTS] error:', e); speaking = false; pump(); };
+    u.onend = () => { console.log('[TTS] end'); speaking = false; pump(); };
+    try { window.speechSynthesis.speak(u); }
+    catch (e) { console.warn('[TTS] speak threw', e); speaking = false; }
+  }
+
+  function enqueue(text: string): void {
+    if (isMuted()) return;
+    q.push(text);
+    pump();
+  }
+
+  return { enqueue };
+}
+


### PR DESCRIPTION
## Summary
- Load the renderer script from the control panel HTML so UI interactions trigger speech
- Factor speech synthesis into a dedicated module and warm voices on first interaction
- Touch up control panel styling and document quick speech test steps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:renderer`


------
https://chatgpt.com/codex/tasks/task_e_68981cb45b6083269854eb2d1236690d